### PR TITLE
Remove COPY node_modules from Dockerfile

### DIFF
--- a/docs-importer/Dockerfile
+++ b/docs-importer/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:14.2-alpine AS builder
 WORKDIR /build
-COPY node_modules/ ./node_modules/
 COPY main.js package-lock.json package.json ./
 RUN npm install && npm install -g pkg
 RUN pkg -t node14-alpine-x64 .


### PR DESCRIPTION
`COPY node_modules/ ./node_modules/` was assuming that `npm install` was ran on the host system OR that the node_modules should be part of the repository when cloned.  
  
Which results in an error when trying to build the image:  
`COPY failed: stat /var/lib/docker/tmp/docker-builder988772680/node_modules: no such file or directory`  
  
I think the rest is correct, though I do still have some trouble running the built image I have locally saying "env.sh" is missing but I can see that the file is there. Maybe because I am building a Linux image from Windows 🤔 

Edit:  
Can confirm that this builds correctly on Docker Hub and works as expected.