### PR TITLE
Add file filter to importer

### DIFF
--- a/docs-importer/Dockerfile
+++ b/docs-importer/Dockerfile
@@ -6,7 +6,7 @@ RUN npm install && npm install -g pkg
 RUN pkg -t node14-alpine-x64 .
 
 FROM alpine
-ENV TEEDY_TAG= TEEDY_ADDTAGS=false TEEDY_LANG=eng TEEDY_URL='http://localhost:8080' TEEDY_USERNAME=username TEEDY_PASSWORD=password TEEDY_COPYFOLDER=
+ENV TEEDY_TAG= TEEDY_ADDTAGS=false TEEDY_LANG=eng TEEDY_URL='http://localhost:8080' TEEDY_USERNAME=username TEEDY_PASSWORD=password TEEDY_COPYFOLDER= TEEDY_FILEFILTER=
 RUN apk add --no-cache \
     libc6-compat \
     libstdc++ 

--- a/docs-importer/README.md
+++ b/docs-importer/README.md
@@ -37,7 +37,7 @@ docker build -t teedy-import .
 docker run --name teedy-import -d -v /path/to/preferencefile:/root/.config/preferences/com.sismics.docs.importer.pref -v /path/to/import/folder:/import teedy-import
 ```
 ### Environment variables
-Instead of mounting the preferences file, the options can also be set by setting the environment variables `TEEDY_TAG`, `TEEDY_ADDTAGS`, `TEEDY_LANG`, `TEEDY_COPYFOLDER`, `TEEDY_URL`, `TEEDY_USERNAME` and `TEEDY_PASSWORD`.
+Instead of mounting the preferences file, the options can also be set by setting the environment variables `TEEDY_TAG`, `TEEDY_ADDTAGS`, `TEEDY_LANG`, `TEEDY_COPYFOLDER`, `TEEDY_FILEFILTER`, `TEEDY_URL`, `TEEDY_USERNAME` and `TEEDY_PASSWORD`.
 The latter three have to be set for the importer to work. The value of `TEEDY_TAG` has to be set to the UUID of the tag, not the name (The UUID can be found by visiting `baseUrl/api/tag/list` in your browser).
 Example usage:
 

--- a/docs-importer/env.sh
+++ b/docs-importer/env.sh
@@ -7,4 +7,5 @@ sed -i "s,env4,$TEEDY_URL,g" $file
 sed -i "s/env5/$TEEDY_USERNAME/g" $file
 sed -i "s/env6/$TEEDY_PASSWORD/g" $file
 sed -i "s,env7,$TEEDY_COPYFOLDER,g" $file
+sed -i "s,env8,$TEEDY_FILEFILTER,g" $file
 echo "Environment variables replaced"

--- a/docs-importer/main.js
+++ b/docs-importer/main.js
@@ -142,10 +142,29 @@ const askPath = () => {
 
         recursive(answers.path, function (error, files) {
           spinner.succeed(files.length + ' files in this directory');
-          askTag();
+          askFileFilter();
         });
       });
     });
+  });
+};
+
+// Ask for the file filter
+const askFileFilter = () => {
+  console.log('');
+
+  inquirer.prompt([
+    {
+      type: 'input',
+      name: 'fileFilter',
+      message: 'What pattern do you want to use to match files? (eg. *.+(pdf|txt|jpg) - defaults to *)',
+      default: prefs.importer.fileFilter
+    }
+  ]).then(answers => {
+    // Save fileFilter
+    prefs.importer.fileFilter = answers.fileFilter  ? answers.fileFilter : '*';
+
+    askTag();
   });
 };
 
@@ -464,7 +483,8 @@ if (argv.hasOwnProperty('d')) {
     'Add tags given #: ' + prefs.importer.addtags + '\n' +
     'Language: ' + prefs.importer.lang + '\n' +
     'Daemon mode: ' + prefs.importer.daemon + '\n' +
-    'Copy folder: ' + prefs.importer.copyFolder
+    'Copy folder: ' + prefs.importer.copyFolder + '\n' +
+    'File filter: ' + prefs.importer.fileFilter
     );
   start();
 } else {

--- a/docs-importer/main.js
+++ b/docs-importer/main.js
@@ -158,12 +158,12 @@ const askFileFilter = () => {
     {
       type: 'input',
       name: 'fileFilter',
-      message: 'What pattern do you want to use to match files? (eg. *.+(pdf|txt|jpg) - defaults to *)',
-      default: prefs.importer.fileFilter
+      message: 'What pattern do you want to use to match files? (eg. *.+(pdf|txt|jpg))',
+      default: prefs.importer.fileFilter || "*"
     }
   ]).then(answers => {
     // Save fileFilter
-    prefs.importer.fileFilter = answers.fileFilter  ? answers.fileFilter : '*';
+    prefs.importer.fileFilter = answers.fileFilter;
 
     askTag();
   });

--- a/docs-importer/main.js
+++ b/docs-importer/main.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const recursive = require('recursive-readdir');
+const minimatch = require("minimatch");
 const ora = require('ora');
 const inquirer = require('inquirer');
 const preferences = require('preferences');
@@ -363,6 +364,8 @@ const start = () => {
 // Import the files
 const importFiles = (remove, filesImported) => {
   recursive(prefs.importer.path, function (error, files) {
+
+    files = files.filter(minimatch.filter(prefs.importer.fileFilter ?? "*", {matchBase: true}));
     if (files.length === 0) {
       filesImported();
       return;

--- a/docs-importer/package.json
+++ b/docs-importer/package.json
@@ -26,6 +26,7 @@
     "preferences": "^1.0.2",
     "qs": "^6.9.4",
     "recursive-readdir": "^2.2.2",
+    "minimatch": "^3.0.4",
     "request": "^2.83.0",
     "underscore": "^1.8.3"
   }

--- a/docs-importer/pref
+++ b/docs-importer/pref
@@ -8,3 +8,4 @@ importer:
   username: 'env5'
   password: 'env6'
   copyFolder: 'env7'
+  fileFilter: 'env8'


### PR DESCRIPTION
In my case, my scanner likes to create a temporary file in the folder that is being watched by the importer. So in the current form, the importer than imports a garbage file.

This adds a whitelist filter (*I saw `recursive-readdir` has a blacklist approach built it but I thought that would suck to use*) using `minimatch`, which is a dependency of `recursive-readdir`, to allow for patterns like `*.+(pdf)` which I am using myself.  
  
If this value is left empty int he wizard then it defaults to the wildcard `*`.