### PR TITLE
Fix tag-adding bugs of the importer

### DIFF
--- a/docs-importer/main.js
+++ b/docs-importer/main.js
@@ -393,6 +393,12 @@ const importFile = (file, remove, resolve) => {
     // Intersect tags from filename with existing tags on server
     let foundtags = [];
     for (let j of taglist) {
+      // If the tag is last in the filename it could include a file extension and would not be recognized
+      if (j.includes('.') && !tagsarray.hasOwnProperty(j) && !foundtags.includes(tagsarray[j])) {
+        while (j.includes('.') && !tagsarray.hasOwnProperty(j)) {
+          j = j.replace(/\.[^.]*$/,'');
+        }
+      }
       if (tagsarray.hasOwnProperty(j) && !foundtags.includes(tagsarray[j])) {
         foundtags.push(tagsarray[j]);
         filename = filename.split('#'+j).join('');

--- a/docs-importer/main.js
+++ b/docs-importer/main.js
@@ -413,7 +413,8 @@ const importFile = (file, remove, resolve) => {
     else {
       data = {
         title: prefs.importer.addtags ? filename : file.replace(/^.*[\\\/]/, '').substring(0, 100),
-        language: prefs.importer.lang || 'eng'
+        language: prefs.importer.lang || 'eng',
+        tags: prefs.importer.tag === '' ? undefined : prefs.importer.tag
       }
     }
     // Create document


### PR DESCRIPTION
Found two bugs in my previous PR:
- If tags were given at the end of the filename like #aaaa.pdf, the importer would look for a tag aaaa.pdf and would not find it.
- If the addtags option was disabled, the specified tag would not be added
