### PR TITLE
Added support for TLS & STARTTLS for SMTP connections

### DIFF
--- a/docs-core/src/main/java/com/sismics/util/EmailUtil.java
+++ b/docs-core/src/main/java/com/sismics/util/EmailUtil.java
@@ -99,11 +99,16 @@ public class EmailUtil {
             }
 
             // Port
+            int port = ConfigUtil.getConfigIntegerValue(ConfigType.SMTP_PORT);
             String envPort = System.getenv(Constants.SMTP_PORT_ENV);
-            if (envPort == null) {
-                email.setSmtpPort(ConfigUtil.getConfigIntegerValue(ConfigType.SMTP_PORT));
-            } else {
-                email.setSmtpPort(Integer.valueOf(envPort));
+            if (envPort != null) {
+                port = Integer.valueOf(envPort);
+            }
+            email.setSmtpPort(port);
+            if (port == 465) {
+                email.setSSLOnConnect(true);
+            } else if (port == 587) {
+                email.setStartTLSRequired(true);
             }
 
             // Username and password


### PR DESCRIPTION
Tested sending a password reset email using TLS with a Gmail account using smtp.gmail.com:465.

A checkbox to enable/disable TLS could be added to support weirdo non-standard SMTP servers that are e.g. running on port 465 but _not_ using TLS, or to support SMTP servers using TLS on a non-standard port.  Or TLS/STARTTLS could be automatically detected with some more code.  But just doing this small change probably covers 99% of cases without making the user have to think and is probably good enough for now.