### PR TITLE
Fix tag-colors inside inherited acl

### DIFF
--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
@@ -104,6 +104,7 @@ public class DocumentResource extends BaseResource {
      * @apiSuccess {String="READ","WRITE"} inherited_acls.perm Permission
      * @apiSuccess {String} inherited_acls.source_id Source ID
      * @apiSuccess {String} inherited_acls.source_name Source name
+     * @apiSuccess {String} inherited_acls.source_color The color of the Source
      * @apiSuccess {String} inherited_acls.id ID
      * @apiSuccess {String} inherited_acls.name Target name
      * @apiSuccess {String="USER","GROUP","SHARE"} inherited_acls.type Target type
@@ -196,6 +197,7 @@ public class DocumentResource extends BaseResource {
                             .add("perm", aclDto.getPerm().name())
                             .add("source_id", tagDto.getId())
                             .add("source_name", tagDto.getName())
+                            .add("source_color", tagDto.getColor())
                             .add("id", aclDto.getTargetId())
                             .add("name", JsonUtil.nullable(aclDto.getTargetName()))
                             .add("type", aclDto.getTargetType()));

--- a/docs-web/src/main/webapp/src/partial/docs/document.view.permissions.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.view.permissions.html
@@ -22,7 +22,7 @@
     <tr ng-repeat="(id, acl) in inheritedAcls">
       <td>
         <a href="#/tag/{{ acl[0].source_id }}">
-          <span class="fas fa-tags"></span>&nbsp;
+          <span class="fas fa-tags" ng-style="{ 'color': acl[0].source_color }"></span>&nbsp;
           {{ acl[0].source_name }}
         </a>
       </td>


### PR DESCRIPTION
I have noticed that the tags within the documents permissions tab do not have the correct color. As I think this is not the intended behavior I have adjusted the code in order to show the specified tag colors.
- If there are other ACL-inheritance-sources planned than tags then the color most probably should not be defined this way and this pull-request will have to be adjusted. At the moment I am under the impression, that tags are the only inheritance source.