### PR TITLE
Add custom parameter for exact search by title

### DIFF
--- a/docs-core/src/main/java/com/sismics/docs/core/dao/criteria/DocumentCriteria.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/criteria/DocumentCriteria.java
@@ -52,7 +52,7 @@ public class DocumentCriteria {
     private List<List<String>> tagIdList;
     
     /**
-     * Tag IDs to excluded.
+     * Tag IDs to exclude.
      * The first and second level list will be excluded.
      */
     private List<List<String>> excludedTagIdList;
@@ -81,7 +81,12 @@ public class DocumentCriteria {
      * MIME type of a file.
      */
     private String mimeType;
-    
+
+    /**
+     * The title.
+     */
+    private String title;
+
     public List<String> getTargetIdList() {
         return targetIdList;
     }
@@ -193,5 +198,13 @@ public class DocumentCriteria {
 
     public void setMimeType(String mimeType) {
         this.mimeType = mimeType;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
     }
 }

--- a/docs-core/src/main/java/com/sismics/docs/core/util/indexing/LuceneIndexingHandler.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/util/indexing/LuceneIndexingHandler.java
@@ -295,6 +295,10 @@ public class LuceneIndexingHandler implements IndexingHandler {
             criteriaList.add("d.DOC_UPDATEDATE_D <= :updateDateMax");
             parameterMap.put("updateDateMax", criteria.getUpdateDateMax());
         }
+        if (criteria.getTitle() != null) {
+            criteriaList.add("d.DOC_TITLE_C = :title");
+            parameterMap.put("title", criteria.getTitle());
+        }
         if (criteria.getTagIdList() != null && !criteria.getTagIdList().isEmpty()) {
             int index = 0;
             for (List<String> tagIdList : criteria.getTagIdList()) {

--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
@@ -598,6 +598,10 @@ public class DocumentResource extends BaseResource {
                     // New fulltext search criteria
                     fullQuery.add(params[1]);
                     break;
+                case "title":
+                    // New title criteria
+                    documentCriteria.setTitle(params[1]);
+                    break;
                 default:
                     fullQuery.add(criteria);
                     break;

--- a/docs-web/src/test/java/com/sismics/docs/rest/TestDocumentResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestDocumentResource.java
@@ -143,7 +143,7 @@ public class TestDocumentResource extends BaseJerseyTest {
         json = target().path("/document").request()
                 .cookie(TokenBasedSecurityFilter.COOKIE_NAME, document3Token)
                 .put(Entity.form(new Form()
-                        .param("title", "My super title document 3")
+                        .param("title", "My_super_title_document_3")
                         .param("description", "My super description for document 3")
                         .param("language", "eng")
                         .param("create_date", Long.toString(create3Date))), JsonObject.class);
@@ -217,6 +217,7 @@ public class TestDocumentResource extends BaseJerseyTest {
         Assert.assertEquals(1, searchDocuments("mime:image/png", document1Token));
         Assert.assertEquals(0, searchDocuments("mime:empty/void", document1Token));
         Assert.assertEquals(1, searchDocuments("after:2010 before:2040-08 tag:super shared:yes lang:eng simple:title simple:description full:uranium", document1Token));
+        Assert.assertEquals(1, searchDocuments("title:My_super_title_document_3", document3Token));
 
         // Search documents (nothing)
         Assert.assertEquals(0, searchDocuments("random", document1Token));
@@ -228,6 +229,7 @@ public class TestDocumentResource extends BaseJerseyTest {
         Assert.assertEquals(0, searchDocuments("before:2040-05-38", document1Token));
         Assert.assertEquals(0, searchDocuments("tag:Nop", document1Token));
         Assert.assertEquals(0, searchDocuments("lang:fra", document1Token));
+        Assert.assertEquals(0, searchDocuments("title:Unknown title", document3Token));
 
         // Get document 1
         json = target().path("/document/" + document1Id).request()


### PR DESCRIPTION
Intended to fix https://github.com/sismics/docs/issues/563

The current code only works when titles contains no space characters, because `com.sismics.docs.rest.resource.DocumentResource#parseSearchQuery` doesn't support escaping when it splits by space characters.

It's not a problem for us but it makes the thing less usefull in the general case.

=> Should I add some escaping logic in the code, or do you think the behaviour change could create regressions on existing usages and it's a bad idea?

Thanks!