### PR TITLE
Support audio mime

### DIFF
--- a/docs-core/src/main/java/com/sismics/util/mime/MimeTypeUtil.java
+++ b/docs-core/src/main/java/com/sismics/util/mime/MimeTypeUtil.java
@@ -5,7 +5,6 @@ import org.apache.commons.compress.utils.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -43,9 +42,8 @@ public class MimeTypeUtil {
      * @param headerBytes File header (first bytes)
      * @param name File name
      * @return MIME type
-     * @throws UnsupportedEncodingException e
      */
-    public static String guessMimeType(byte[] headerBytes, String name) throws UnsupportedEncodingException {
+    public static String guessMimeType(byte[] headerBytes, String name) {
         String header = new String(headerBytes, StandardCharsets.US_ASCII);
 
         // Detect by header bytes

--- a/docs-core/src/main/java/com/sismics/util/mime/MimeTypeUtil.java
+++ b/docs-core/src/main/java/com/sismics/util/mime/MimeTypeUtil.java
@@ -5,6 +5,7 @@ import org.apache.commons.compress.utils.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,11 +27,13 @@ public class MimeTypeUtil {
      * @throws IOException e
      */
     public static String guessMimeType(Path file, String name) throws IOException {
-        String mimeType;
-        try (InputStream is = Files.newInputStream(file)) {
-            byte[] headerBytes = new byte[64];
-            is.read(headerBytes);
-            mimeType = guessMimeType(headerBytes, name);
+        String mimeType = URLConnection.getFileNameMap().getContentTypeFor(name);
+        if (mimeType == null) {
+            try (InputStream is = Files.newInputStream(file)) {
+                final byte[] headerBytes = new byte[64];
+                is.read(headerBytes);
+                mimeType = guessMimeType(headerBytes, name);
+            }
         }
 
         return guessOpenDocumentFormat(mimeType, file);

--- a/docs-core/src/main/java/com/sismics/util/mime/MimeTypeUtil.java
+++ b/docs-core/src/main/java/com/sismics/util/mime/MimeTypeUtil.java
@@ -6,6 +6,7 @@ import org.apache.commons.compress.utils.IOUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.zip.ZipEntry;
@@ -45,7 +46,7 @@ public class MimeTypeUtil {
      * @throws UnsupportedEncodingException e
      */
     public static String guessMimeType(byte[] headerBytes, String name) throws UnsupportedEncodingException {
-        String header = new String(headerBytes, "US-ASCII");
+        String header = new String(headerBytes, StandardCharsets.US_ASCII);
 
         // Detect by header bytes
         if (header.startsWith("PK")) {

--- a/docs-web/src/main/webapp/src/partial/docs/file.view.html
+++ b/docs-web/src/main/webapp/src/partial/docs/file.view.html
@@ -41,8 +41,8 @@
        img-error="error = true"
        ng-show="!error && canDisplayPreview()" />
 
-  <!-- Video player -->
-  <a href class="video-overlay" ng-if="!error && file.mimetype.substring(0, 6) == 'video/'"
+  <!-- Media player -->
+  <a href class="video-overlay" ng-if="!error && (file.mimetype.substring(0, 6) == 'video/' || file.mimetype.substring(0, 6) == 'audio/')"
      ng-init="videoPlayer = false" ng-click="videoPlayer = true">
     <span class="fas fa-play-circle" ng-if="!videoPlayer"></span>
     <video ng-if="videoPlayer" autoplay="autoplay" loop="loop"


### PR DESCRIPTION
I noticed that my audio files where all marked as `application/octet-stream`, i've used another method to determine the mimetype from the filename, with the current method as fallback.
I also enabled the media player for audio files