### PR TITLE
Hide workflow-tab if not applicable

### DIFF
--- a/docs-web/src/main/webapp/src/app/docs/controller/document/DocumentView.js
+++ b/docs-web/src/main/webapp/src/app/docs/controller/document/DocumentView.js
@@ -164,4 +164,13 @@ angular.module('docs').controller('DocumentView', function ($scope, $rootScope, 
       }
     });
   };
+
+  /**
+   * Count routes.
+   */
+  // Load route models
+  Restangular.one('routemodel').get().then(function(data) {
+    $scope.routeCount = data.routemodels.length;
+  });
+
 });

--- a/docs-web/src/main/webapp/src/partial/docs/document.view.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.view.html
@@ -76,7 +76,7 @@
             <span class="fas fa-file"></span> {{ 'document.view.content' | translate }}
           </a>
         </li>
-        <li ng-class="{ active: $state.current.name == 'document.view.workflow' }">
+        <li ng-class="{ active: $state.current.name == 'document.view.workflow' }" ng-show="routeCount > 0">
           <a href="#/document/view/{{ document.id }}/workflow">
             <span class="fas fa-random"></span> {{ 'document.view.workflow' | translate }}
           </a>


### PR DESCRIPTION
If there are no workflows configured in the settings, the workflow tab can be hidden on the document page