### PR TITLE
Remove duplicate tesseract language from dockerfile and cleanup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,36 @@
 FROM sismics/ubuntu-jetty:9.4.12-2
-MAINTAINER b.gamard@sismics.com
+LABEL maintainer="b.gamard@sismics.com"
 
-RUN apt-get update && apt-get -y -q install ffmpeg mediainfo tesseract-ocr tesseract-ocr-fra tesseract-ocr-ita tesseract-ocr-kor tesseract-ocr-rus tesseract-ocr-ukr tesseract-ocr-spa tesseract-ocr-ara tesseract-ocr-hin tesseract-ocr-deu tesseract-ocr-pol tesseract-ocr-jpn tesseract-ocr-por tesseract-ocr-tha tesseract-ocr-jpn tesseract-ocr-chi-sim tesseract-ocr-chi-tra tesseract-ocr-nld tesseract-ocr-tur tesseract-ocr-heb tesseract-ocr-hun tesseract-ocr-fin tesseract-ocr-swe tesseract-ocr-lav tesseract-ocr-dan tesseract-ocr-nor tesseract-ocr-vie && \
+RUN apt-get update && \
+    apt-get -y -q --no-install-recommends install \
+    ffmpeg \
+    mediainfo \
+    tesseract-ocr \
+    tesseract-ocr-ara \
+    tesseract-ocr-chi-sim \
+    tesseract-ocr-chi-tra \
+    tesseract-ocr-dan \
+    tesseract-ocr-deu \
+    tesseract-ocr-fin \
+    tesseract-ocr-fra \
+    tesseract-ocr-heb \
+    tesseract-ocr-hin \
+    tesseract-ocr-hun \
+    tesseract-ocr-ita \
+    tesseract-ocr-jpn \
+    tesseract-ocr-kor \
+    tesseract-ocr-lav \
+    tesseract-ocr-nld \
+    tesseract-ocr-nor \
+    tesseract-ocr-pol \
+    tesseract-ocr-por \
+    tesseract-ocr-rus \
+    tesseract-ocr-spa \
+    tesseract-ocr-swe \
+    tesseract-ocr-tha \
+    tesseract-ocr-tur \
+    tesseract-ocr-ukr \
+    tesseract-ocr-vie && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Remove the embedded javax.mail jar from Jetty


### PR DESCRIPTION
Apt packages had a duplicate line.

Remove duplicate, alphabetize lines to make it easier to prevent reoccurring. 

Add "--no-install-recommends" to `apt` so extra packages are not pulled in. 

Lastly, convert MAINTAINER tag to LABEL per docker best practices.