### PR TITLE
Check if environment variables are not empty strings as well as not null

### DIFF
--- a/docs-core/src/main/java/com/sismics/docs/core/dao/UserDao.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/UserDao.java
@@ -1,6 +1,7 @@
 package com.sismics.docs.core.dao;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import at.favre.lib.crypto.bcrypt.BCrypt;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -289,7 +290,7 @@ public class UserDao {
     private String hashPassword(String password) {
         int bcryptWork = Constants.DEFAULT_BCRYPT_WORK;
         String envBcryptWork = System.getenv(Constants.BCRYPT_WORK_ENV);
-        if (envBcryptWork != null) {
+        if (!Strings.isNullOrEmpty(envBcryptWork)) {
             try {
                 int envBcryptWorkInt = Integer.parseInt(envBcryptWork);
                 if (envBcryptWorkInt >= 4 && envBcryptWorkInt <= 31) {

--- a/docs-core/src/main/java/com/sismics/docs/core/model/context/AppContext.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/model/context/AppContext.java
@@ -1,5 +1,6 @@
 package com.sismics.docs.core.model.context;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.eventbus.AsyncEventBus;
 import com.google.common.eventbus.EventBus;
@@ -106,7 +107,7 @@ public class AppContext {
 
         // Change the admin password if needed
         String envAdminPassword = System.getenv(Constants.ADMIN_PASSWORD_INIT_ENV);
-        if (envAdminPassword != null) {
+        if (!Strings.isNullOrEmpty(envAdminPassword)) {
             UserDao userDao = new UserDao();
             User adminUser = userDao.getById("admin");
             if (Constants.DEFAULT_ADMIN_PASSWORD.equals(adminUser.getPassword())) {
@@ -117,7 +118,7 @@ public class AppContext {
 
         // Change the admin email if needed
         String envAdminEmail = System.getenv(Constants.ADMIN_EMAIL_INIT_ENV);
-        if (envAdminEmail != null) {
+        if (!Strings.isNullOrEmpty(envAdminEmail)) {
             UserDao userDao = new UserDao();
             User adminUser = userDao.getById("admin");
             if (Constants.DEFAULT_ADMIN_EMAIL.equals(adminUser.getEmail())) {

--- a/docs-core/src/main/java/com/sismics/util/EmailUtil.java
+++ b/docs-core/src/main/java/com/sismics/util/EmailUtil.java
@@ -92,7 +92,7 @@ public class EmailUtil {
 
             // Hostname
             String envHostname = System.getenv(Constants.SMTP_HOSTNAME_ENV);
-            if (envHostname == null) {
+            if (Strings.isNullOrEmpty(envHostname)) {
                 email.setHostName(ConfigUtil.getConfigStringValue(ConfigType.SMTP_HOSTNAME));
             } else {
                 email.setHostName(envHostname);
@@ -101,7 +101,7 @@ public class EmailUtil {
             // Port
             int port = ConfigUtil.getConfigIntegerValue(ConfigType.SMTP_PORT);
             String envPort = System.getenv(Constants.SMTP_PORT_ENV);
-            if (envPort != null) {
+            if (!Strings.isNullOrEmpty(envPort)) {
                 port = Integer.valueOf(envPort);
             }
             email.setSmtpPort(port);
@@ -114,7 +114,7 @@ public class EmailUtil {
             // Username and password
             String envUsername = System.getenv(Constants.SMTP_USERNAME_ENV);
             String envPassword = System.getenv(Constants.SMTP_PASSWORD_ENV);
-            if (envUsername == null || envPassword == null) {
+            if (Strings.isNullOrEmpty(envUsername) || Strings.isNullOrEmpty(envPassword)) {
                 Config usernameConfig = configDao.getById(ConfigType.SMTP_USERNAME);
                 Config passwordConfig = configDao.getById(ConfigType.SMTP_PASSWORD);
                 if (usernameConfig != null && passwordConfig != null) {

--- a/docs-core/src/main/java/com/sismics/util/jpa/EMF.java
+++ b/docs-core/src/main/java/com/sismics/util/jpa/EMF.java
@@ -1,5 +1,6 @@
 package com.sismics.util.jpa;
 
+import com.google.common.base.Strings;
 import com.sismics.docs.core.util.DirectoryUtil;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.internal.util.config.ConfigurationHelper;
@@ -83,7 +84,7 @@ public final class EMF {
         Map<Object, Object> props = new HashMap<>();
         Path dbDirectory = DirectoryUtil.getDbDirectory();
         String dbFile = dbDirectory.resolve("docs").toAbsolutePath().toString();
-        if (databaseUrl == null) {
+        if (Strings.isNullOrEmpty(databaseUrl)) {
             props.put("hibernate.connection.driver_class", "org.h2.Driver");
             props.put("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
             props.put("hibernate.connection.url", "jdbc:h2:file:" + dbFile + ";CACHE_SIZE=65536;LOCK_TIMEOUT=10000");

--- a/docs-web-common/src/test/java/com/sismics/docs/rest/BaseJerseyTest.java
+++ b/docs-web-common/src/test/java/com/sismics/docs/rest/BaseJerseyTest.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Base class of integration tests with Jersey.
@@ -56,7 +57,7 @@ public abstract class BaseJerseyTest extends JerseyTest {
     @Override
     protected Application configure() {
         String travisEnv = System.getenv("TRAVIS");
-        if (travisEnv == null || !travisEnv.equals("true")) {
+        if (!Objects.equals(travisEnv, "true")) {
             // Travis doesn't like big logs
             enable(TestProperties.LOG_TRAFFIC);
             enable(TestProperties.DUMP_ENTITY);

--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/AppResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/AppResource.java
@@ -205,28 +205,28 @@ public class AppResource extends BaseResource {
         Config passwordConfig = configDao.getById(ConfigType.SMTP_PASSWORD);
         Config fromConfig = configDao.getById(ConfigType.SMTP_FROM);
         JsonObjectBuilder response = Json.createObjectBuilder();
-        if (System.getenv(Constants.SMTP_HOSTNAME_ENV) == null) {
+        if (Strings.isNullOrEmpty(System.getenv(Constants.SMTP_HOSTNAME_ENV))) {
             if (hostnameConfig == null) {
                 response.addNull("hostname");
             } else {
                 response.add("hostname", hostnameConfig.getValue());
             }
         }
-        if (System.getenv(Constants.SMTP_PORT_ENV) == null) {
+        if (Strings.isNullOrEmpty(System.getenv(Constants.SMTP_PORT_ENV))) {
             if (portConfig == null) {
                 response.addNull("port");
             } else {
                 response.add("port", Integer.valueOf(portConfig.getValue()));
             }
         }
-        if (System.getenv(Constants.SMTP_USERNAME_ENV) == null) {
+        if (Strings.isNullOrEmpty(System.getenv(Constants.SMTP_USERNAME_ENV))) {
             if (usernameConfig == null) {
                 response.addNull("username");
             } else {
                 response.add("username", usernameConfig.getValue());
             }
         }
-        if (System.getenv(Constants.SMTP_PASSWORD_ENV) == null) {
+        if (Strings.isNullOrEmpty(System.getenv(Constants.SMTP_PASSWORD_ENV))) {
             if (passwordConfig == null) {
                 response.addNull("password");
             } else {


### PR DESCRIPTION
When trying to use teedy with the k8s-at-home chart, it sets the environment variables to be empty strings when not set. 

This is actually quite common so usually `Strings.isNullOrEmpty` or similar is used to check if that is the case. You do this in one or two places in your codebase already. This just makes the codebase consistently do this.

A bug has been filed on k8s-at-home too: https://github.com/k8s-at-home/charts/issues/1422