### PR TITLE
Small code cleaning

### DIFF
--- a/docs-core/src/main/java/com/sismics/docs/core/dao/FileDao.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/FileDao.java
@@ -7,7 +7,6 @@ import com.sismics.util.context.ThreadLocalContext;
 
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
-import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 import java.util.Collections;
 import java.util.Date;
@@ -49,10 +48,9 @@ public class FileDao {
      * @param limit Limit
      * @return List of files
      */
-    @SuppressWarnings("unchecked")
     public List<File> findAll(int offset, int limit) {
         EntityManager em = ThreadLocalContext.get().getEntityManager();
-        Query q = em.createQuery("select f from File f where f.deleteDate is null");
+        TypedQuery<File> q = em.createQuery("select f from File f where f.deleteDate is null", File.class);
         q.setFirstResult(offset);
         q.setMaxResults(limit);
         return q.getResultList();
@@ -64,10 +62,9 @@ public class FileDao {
      * @param userId User ID
      * @return List of files
      */
-    @SuppressWarnings("unchecked")
     public List<File> findByUserId(String userId) {
         EntityManager em = ThreadLocalContext.get().getEntityManager();
-        Query q = em.createQuery("select f from File f where f.userId = :userId and f.deleteDate is null");
+        TypedQuery<File> q = em.createQuery("select f from File f where f.userId = :userId and f.deleteDate is null", File.class);
         q.setParameter("userId", userId);
         return q.getResultList();
     }
@@ -76,14 +73,14 @@ public class FileDao {
      * Returns an active file.
      * 
      * @param id File ID
-     * @return Document
+     * @return File
      */
     public File getFile(String id) {
         EntityManager em = ThreadLocalContext.get().getEntityManager();
-        Query q = em.createQuery("select f from File f where f.id = :id and f.deleteDate is null");
+        TypedQuery<File> q = em.createQuery("select f from File f where f.id = :id and f.deleteDate is null", File.class);
         q.setParameter("id", id);
         try {
-            return (File) q.getSingleResult();
+            return q.getSingleResult();
         } catch (NoResultException e) {
             return null;
         }
@@ -94,15 +91,15 @@ public class FileDao {
      * 
      * @param id File ID
      * @param userId User ID
-     * @return Document
+     * @return File
      */
     public File getFile(String id, String userId) {
         EntityManager em = ThreadLocalContext.get().getEntityManager();
-        Query q = em.createQuery("select f from File f where f.id = :id and f.userId = :userId and f.deleteDate is null");
+        TypedQuery<File> q = em.createQuery("select f from File f where f.id = :id and f.userId = :userId and f.deleteDate is null", File.class);
         q.setParameter("id", id);
         q.setParameter("userId", userId);
         try {
-            return (File) q.getSingleResult();
+            return q.getSingleResult();
         } catch (NoResultException e) {
             return null;
         }
@@ -118,9 +115,9 @@ public class FileDao {
         EntityManager em = ThreadLocalContext.get().getEntityManager();
             
         // Get the file
-        Query q = em.createQuery("select f from File f where f.id = :id and f.deleteDate is null");
+        TypedQuery<File> q = em.createQuery("select f from File f where f.id = :id and f.deleteDate is null", File.class);
         q.setParameter("id", id);
-        File fileDb = (File) q.getSingleResult();
+        File fileDb = q.getSingleResult();
         
         // Delete the file
         Date dateNow = new Date();
@@ -140,9 +137,9 @@ public class FileDao {
         EntityManager em = ThreadLocalContext.get().getEntityManager();
         
         // Get the file
-        Query q = em.createQuery("select f from File f where f.id = :id and f.deleteDate is null");
+        TypedQuery<File> q = em.createQuery("select f from File f where f.id = :id and f.deleteDate is null", File.class);
         q.setParameter("id", file.getId());
-        File fileDb = (File) q.getSingleResult();
+        File fileDb = q.getSingleResult();
 
         // Update the file
         fileDb.setDocumentId(file.getDocumentId());
@@ -164,10 +161,10 @@ public class FileDao {
      */
     public File getActiveById(String id) {
         EntityManager em = ThreadLocalContext.get().getEntityManager();
-        Query q = em.createQuery("select f from File f where f.id = :id and f.deleteDate is null");
+        TypedQuery<File> q = em.createQuery("select f from File f where f.id = :id and f.deleteDate is null", File.class);
         q.setParameter("id", id);
         try {
-            return (File) q.getSingleResult();
+            return q.getSingleResult();
         } catch (NoResultException e) {
             return null;
         }
@@ -210,10 +207,9 @@ public class FileDao {
      * @param versionId Version ID
      * @return List of files
      */
-    @SuppressWarnings("unchecked")
     public List<File> getByVersionId(String versionId) {
         EntityManager em = ThreadLocalContext.get().getEntityManager();
-        Query q = em.createQuery("select f from File f where f.versionId = :versionId and f.deleteDate is null order by f.order asc");
+        TypedQuery<File> q = em.createQuery("select f from File f where f.versionId = :versionId and f.deleteDate is null order by f.order asc", File.class);
         q.setParameter("versionId", versionId);
         return q.getResultList();
     }

--- a/docs-core/src/main/java/com/sismics/docs/core/util/FileUtil.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/util/FileUtil.java
@@ -1,6 +1,5 @@
 package com.sismics.docs.core.util;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.io.CharStreams;
@@ -28,6 +27,7 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -76,7 +76,7 @@ public class FileUtil {
 
         // Consume the data as text
         try (InputStream is = process.getInputStream()) {
-            return CharStreams.toString(new InputStreamReader(is, Charsets.UTF_8));
+            return CharStreams.toString(new InputStreamReader(is, StandardCharsets.UTF_8));
         }
     }
 

--- a/docs-core/src/main/java/com/sismics/docs/core/util/format/TextPlainFormatHandler.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/util/format/TextPlainFormatHandler.java
@@ -11,6 +11,7 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 
 import java.awt.image.BufferedImage;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -33,7 +34,7 @@ public class TextPlainFormatHandler implements FormatHandler {
         PdfWriter.getInstance(output, pdfOutputStream);
 
         output.open();
-        String content = new String(Files.readAllBytes(file), Charsets.UTF_8);
+        String content = Files.readString(file, StandardCharsets.UTF_8);
         Font font = FontFactory.getFont("LiberationMono-Regular");
         Paragraph paragraph = new Paragraph(content, font);
         paragraph.setAlignment(Element.ALIGN_LEFT);
@@ -46,7 +47,7 @@ public class TextPlainFormatHandler implements FormatHandler {
 
     @Override
     public String extractContent(String language, Path file) throws Exception {
-        return new String(Files.readAllBytes(file), "UTF-8");
+        return Files.readString(file, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/docs-core/src/main/java/com/sismics/docs/core/util/format/VideoFormatHandler.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/util/format/VideoFormatHandler.java
@@ -1,6 +1,5 @@
 package com.sismics.docs.core.util.format;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closer;
@@ -13,6 +12,7 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -65,7 +65,7 @@ public class VideoFormatHandler implements FormatHandler {
 
         // Consume the data as a string
         try (InputStream is = process.getInputStream()) {
-            return new String(ByteStreams.toByteArray(is), Charsets.UTF_8);
+            return new String(ByteStreams.toByteArray(is), StandardCharsets.UTF_8);
         } catch (Exception e) {
             return null;
         }

--- a/docs-core/src/main/java/com/sismics/util/EmailUtil.java
+++ b/docs-core/src/main/java/com/sismics/util/EmailUtil.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -87,7 +88,7 @@ public class EmailUtil {
         try {
             // Build email headers
             HtmlEmail email = new HtmlEmail();
-            email.setCharset("UTF-8");
+            email.setCharset(StandardCharsets.UTF_8.name());
             ConfigDao configDao = new ConfigDao();
 
             // Hostname

--- a/docs-core/src/main/java/com/sismics/util/ImageUtil.java
+++ b/docs-core/src/main/java/com/sismics/util/ImageUtil.java
@@ -1,6 +1,5 @@
 package com.sismics.util;
 
-import com.google.common.base.Charsets;
 import com.google.common.hash.Hashing;
 
 import javax.imageio.IIOImage;
@@ -13,6 +12,7 @@ import java.awt.image.BufferedImage;
 import java.awt.image.WritableRaster;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 
 /**
@@ -80,7 +80,7 @@ public class ImageUtil {
         }
 
         return Hashing.md5().hashString(
-                email.trim().toLowerCase(), Charsets.UTF_8)
+                email.trim().toLowerCase(), StandardCharsets.UTF_8)
                 .toString();
     }
 

--- a/docs-core/src/main/java/com/sismics/util/ResourceUtil.java
+++ b/docs-core/src/main/java/com/sismics/util/ResourceUtil.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.*;
 import java.util.jar.JarEntry;
@@ -53,7 +54,7 @@ public class ResourceUtil {
             
             // Extract the JAR path
             String jarPath = dirUrl.getPath().substring(5, dirUrl.getPath().indexOf("!"));
-            JarFile jar = new JarFile(URLDecoder.decode(jarPath, "UTF-8"));
+            JarFile jar = new JarFile(URLDecoder.decode(jarPath, StandardCharsets.UTF_8));
             Set<String> fileSet = new HashSet<String>();
             
             try {

--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/FileResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/FileResource.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
@@ -124,7 +125,7 @@ public class FileResource extends BaseResource {
 
         try {
             String name = fileBodyPart.getContentDisposition() != null ?
-                    URLDecoder.decode(fileBodyPart.getContentDisposition().getFileName(), "UTF-8") : null;
+                    URLDecoder.decode(fileBodyPart.getContentDisposition().getFileName(), StandardCharsets.UTF_8) : null;
             String fileId = FileUtil.createFile(name, previousFileId, unencryptedFile, fileSize, documentDto == null ?
                     null : documentDto.getLanguage(), principal.getId(), documentId);
 


### PR DESCRIPTION
A small PR that does some code cleaning:

- Fix two javadoc errors in FileDao (Document -> File)
- Move UTF-8 usages to `StandardCharsets.UTF_8` (from String and from Guava constants as https://github.com/google/guava/wiki/StringsExplained#charsets )
- Moved `FileDao` queries to `TypeQuery` so the `unchecked` can be removed

These are backports of changed I've made in our main branch, I think they improve the code a bit but, but if you don't want them just tell me.