### PR TITLE
Finding for several documents by their title in a single query

### DIFF
--- a/docs-core/src/main/java/com/sismics/docs/core/dao/criteria/DocumentCriteria.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/criteria/DocumentCriteria.java
@@ -84,9 +84,9 @@ public class DocumentCriteria {
     private String mimeType;
 
     /**
-     * The title.
+     * Titles to include.
      */
-    private String title;
+    private List<String> titleList = new ArrayList<>();
 
     public List<String> getTargetIdList() {
         return targetIdList;
@@ -192,11 +192,7 @@ public class DocumentCriteria {
         this.mimeType = mimeType;
     }
 
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
+    public List<String> getTitleList() {
+        return titleList;
     }
 }

--- a/docs-core/src/main/java/com/sismics/docs/core/util/indexing/LuceneIndexingHandler.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/util/indexing/LuceneIndexingHandler.java
@@ -295,9 +295,9 @@ public class LuceneIndexingHandler implements IndexingHandler {
             criteriaList.add("d.DOC_UPDATEDATE_D <= :updateDateMax");
             parameterMap.put("updateDateMax", criteria.getUpdateDateMax());
         }
-        if (criteria.getTitle() != null) {
-            criteriaList.add("d.DOC_TITLE_C = :title");
-            parameterMap.put("title", criteria.getTitle());
+        if (!criteria.getTitleList().isEmpty()) {
+            criteriaList.add("d.DOC_TITLE_C in :title");
+            parameterMap.put("title", criteria.getTitleList());
         }
         if (!criteria.getTagIdList().isEmpty()) {
             int index = 0;

--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
@@ -497,6 +497,30 @@ public class DocumentResource extends BaseResource {
     }
     
     /**
+     * @param limit      Page limit
+     * @param offset     Page offset
+     * @param sortColumn Sort column
+     * @param asc        Sorting
+     * @param search     Search query
+     * @param files      Files list
+     * @return Response
+     * @api {post} /document/:id Get a document but as a POST endpoint to allow longer search parameters, see "Get a document" documentation for the API info
+     * @apiName GetDocumentPost
+     * @apiGroup Document
+     */
+    @POST
+    @Path("list")
+    public Response listPost(
+            @FormParam("limit") Integer limit,
+            @FormParam("offset") Integer offset,
+            @FormParam("sort_column") Integer sortColumn,
+            @FormParam("asc") Boolean asc,
+            @FormParam("search") String search,
+            @FormParam("files") Boolean files) {
+        return list(limit, offset, sortColumn, asc, search, files);
+    }
+
+    /**
      * Parse a query according to the specified syntax, eg.:
      * tag:assurance tag:other before:2012 after:2011-09 shared:yes lang:fra thing
      *
@@ -663,7 +687,7 @@ public class DocumentResource extends BaseResource {
                     break;
                 case "title":
                     // New title criteria
-                    documentCriteria.setTitle(paramValue);
+                    documentCriteria.getTitleList().add(paramValue);
                     break;
                 default:
                     fullQuery.add(criteria);

--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
@@ -495,8 +495,16 @@ public class DocumentResource extends BaseResource {
         
         return Response.ok().entity(response.build()).build();
     }
-    
+
     /**
+     * Returns all documents.
+     *
+     * @api {post} /document/list Get documents
+     * @apiDescription Get documents exposed as a POST endpoint to allow longer search parameters, see the GET endpoint for the API info
+     * @apiName PostDocumentList
+     * @apiGroup Document
+     * @apiVersion 1.12.0
+     *
      * @param limit      Page limit
      * @param offset     Page offset
      * @param sortColumn Sort column
@@ -504,9 +512,6 @@ public class DocumentResource extends BaseResource {
      * @param search     Search query
      * @param files      Files list
      * @return Response
-     * @api {post} /document/:id Get a document but as a POST endpoint to allow longer search parameters, see "Get a document" documentation for the API info
-     * @apiName GetDocumentPost
-     * @apiGroup Document
      */
     @POST
     @Path("list")

--- a/docs-web/src/main/webapp/header.md
+++ b/docs-web/src/main/webapp/header.md
@@ -77,10 +77,10 @@ If a search `VALUE` is considered invalid, the search result will be empty.
   * `mime:VALUE`: the document must be of the specified mime type (example: `image/png`)
 * Shared
   * `shared:VALUE`: if `VALUE` is `yes`the document must be shared, for other `VALUE`s the criteria is ignored
-* Tags
+* Tags: several `tags` or `!tag:` can be specified and the document must match all filters
   * `tag:VALUE`: the document must contain a tag or a child of a tag that starts with `VALUE`, case is ignored
   * `!tag:VALUE`: the document must not contain a tag or a child of a tag that starts with `VALUE`, case is ignored
-* Title
+* Titles: several `title` can be specified, and the document must match any of the titles
   * `title:VALUE`: the title of the document must be `VALUE`
 * User
   * `by:VALUE`: the document creator's username must be `VALUE` with an exact match, the user must not be deleted


### PR DESCRIPTION
It's an enhancement of the searching by title added in https://github.com/sismics/docs/commit/d98c1bddec454006f185f2e25f94cdd63ae05572 , it allow to specify several titles at the same time so all the corresponding documents are returned.

At first I though about adding a new parameter but at the end I noticed the `tag` parameter can be specified several times so I used the same approach.

Our use case is to be able to quickly download several files scattered in several documents from their titles:
- one API calls find all the documents and their files from the document's name
- one API call download the zipped files

I had to introduce another thing (and I'm not too happy about it, so alternative suggestions are welcome) is to make the document search endpoint available as a `POST` call, because when when I search for a lot of documents at the same time the `GET` URI's are becoming too long and I get `URI Too Long` errors.