### PR TITLE
Allow to specify a database connection pool size using an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ To build external URL, the server is expecting a `DOCS_BASE_URL` environment var
   - `DATABASE_URL`: The jdbc connection string to be used by `hibernate`.
   - `DATABASE_USER`: The user which should be used for the database connection.
   - `DATABASE_PASSWORD`: The password to be used for the database connection.
+  - `DATABASE_POOL_SIZE`: The pool size to be used for the database connection.
 
 - Language
   - `DOCS_DEFAULT_LANGUAGE`: The language which will be used as default. Currently supported values are:
@@ -122,6 +123,7 @@ services:
       DATABASE_URL: "jdbc:postgresql://teedy-db:5432/teedy"
       DATABASE_USER: "teedy_db_user"
       DATABASE_PASSWORD: "teedy_db_password"
+      DATABASE_POOL_SIZE: "10"
     volumes:
       - ./docs/data:/data
     networks:

--- a/docs-core/src/main/java/com/sismics/util/jpa/EMF.java
+++ b/docs-core/src/main/java/com/sismics/util/jpa/EMF.java
@@ -79,6 +79,10 @@ public final class EMF {
         String databaseUrl = System.getenv("DATABASE_URL");
         String databaseUsername = System.getenv("DATABASE_USER");
         String databasePassword = System.getenv("DATABASE_PASSWORD");
+        String databasePoolSize = System.getenv("DATABASE_POOL_SIZE");
+        if(databasePoolSize == null) {
+            databasePoolSize = "10";
+        }
 
         log.info("Configuring EntityManager from environment parameters");
         Map<Object, Object> props = new HashMap<>();
@@ -103,7 +107,7 @@ public final class EMF {
         props.put("hibernate.max_fetch_depth", "5");
         props.put("hibernate.cache.use_second_level_cache", "false");
         props.put("hibernate.connection.initial_pool_size", "1");
-        props.put("hibernate.connection.pool_size", "10");
+        props.put("hibernate.connection.pool_size", databasePoolSize);
         props.put("hibernate.connection.pool_validation_interval", "5");
         return props;
     }


### PR DESCRIPTION
During a load spike we got errors because no connexion was available