### PR TITLE
Upgrade pdfbox version to 2.0.29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <at.favre.lib.bcrypt.version>0.10.2</at.favre.lib.bcrypt.version>
     <org.apache.lucene.version>8.7.0</org.apache.lucene.version>
     <org.imgscalr.imgscalr-lib.version>4.2</org.imgscalr.imgscalr-lib.version>
-    <org.apache.pdfbox.pdfbox.version>2.0.27</org.apache.pdfbox.pdfbox.version>
+    <org.apache.pdfbox.pdfbox.version>2.0.29</org.apache.pdfbox.pdfbox.version>
     <org.bouncycastle.bcprov-jdk15on.version>1.70</org.bouncycastle.bcprov-jdk15on.version>
     <joda-time.joda-time.version>2.12.2</joda-time.joda-time.version>
     <org.hibernate.hibernate.version>6.3.1.Final</org.hibernate.hibernate.version>


### PR DESCRIPTION
The goal is to get rid of the 
```
DEBUG org.apache.pdfbox.io.ScratchFileBuffer.finalize(ScratchFileBuffer.java:518) ScratchFileBuffer not closed!
```
messages in the logs, it could marginaly lower memory consumption since memory is reclaimed when the file is closed vs when it is reclaimed by the GC, see https://issues.apache.org/jira/browse/PDFBOX-5534 for the change.