### PR TITLE
add one click deploy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ services:
 
 # Manual installation
 
+## Self-Host
+Deploy a self-hosted version in one-click with [Dome](https://app.trydome.io/signup?package=teedy):
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=teedy)
+
 ## Requirements
 
 - Java 11


### PR DESCRIPTION
Hey!

We built this one-click deploy link for your users who may not know how to stand up their own infrastructure to easily self-host this.

After deployment, users receive a link like this, which can then be CNAME-ed to any domain:

https://teedy-1177.dome.tools

Take it for a test run—we're eager to receive your feedback! We're more than willing to maintain this for the long haul, if this is valuable for your users.