### PR TITLE
Following up #757 - Fixed remaining non-idempotent tests

### DIFF
--- a/docs-web/src/test/java/com/sismics/docs/rest/TestAuditLogResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestAuditLogResource.java
@@ -118,6 +118,12 @@ public class TestAuditLogResource extends BaseJerseyTest {
         Assert.assertEquals(countByClass(logs, "Document"), 1);
         Assert.assertEquals(countByClass(logs, "Acl"), 2);
         Assert.assertEquals(countByClass(logs, "File"), 1);
+
+        // Delete auditlog1
+        String adminToken = adminToken();
+        target().path("/user/auditlog1").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete();
     }
     
     /**

--- a/docs-web/src/test/java/com/sismics/docs/rest/TestGroupResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestGroupResource.java
@@ -188,5 +188,25 @@ public class TestGroupResource extends BaseJerseyTest {
         Assert.assertEquals(2, groups.size());
         Assert.assertTrue(groupList.contains("g11"));
         Assert.assertTrue(groupList.contains("g112"));
+
+        // Delete all remaining groups and users
+        target().path("/group/g11").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete(JsonObject.class);
+        target().path("/group/g12new").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete(JsonObject.class);
+        target().path("/group/g111").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete(JsonObject.class);
+        target().path("/group/g112").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete(JsonObject.class);
+        target().path("/user/group1").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete();
+        target().path("/user/admin2").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete();
     }
 }

--- a/docs-web/src/test/java/com/sismics/docs/rest/TestRouteModelResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestRouteModelResource.java
@@ -137,5 +137,10 @@ public class TestRouteModelResource extends BaseJerseyTest {
                 .get(JsonObject.class);
         routeModels = json.getJsonArray("routemodels");
         Assert.assertEquals(1, routeModels.size());
+
+        // Deletes routeModel1 user
+        target().path("/user/routeModel1").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete();
     }
 }

--- a/docs-web/src/test/java/com/sismics/docs/rest/TestSecurity.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestSecurity.java
@@ -73,6 +73,12 @@ public class TestSecurity extends BaseJerseyTest {
 
         // User testsecurity logs out
         clientUtil.logout(testSecurityToken);
+
+        // Delete the user
+        String adminToken = adminToken();
+        target().path("/user/testsecurity").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete();
     }
 
     @Test
@@ -98,5 +104,11 @@ public class TestSecurity extends BaseJerseyTest {
                 .header(HeaderBasedSecurityFilter.AUTHENTICATED_USER_HEADER, "idontexist")
                 .get()
                 .getStatus());
+        
+        // Delete the user
+        String adminToken = adminToken();
+        target().path("/user/header_auth_test").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete();
     }
 }

--- a/docs-web/src/test/java/com/sismics/docs/rest/TestShareResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestShareResource.java
@@ -127,5 +127,14 @@ public class TestShareResource extends BaseJerseyTest {
         Assert.assertEquals(Status.BAD_REQUEST, Status.fromStatusCode(response.getStatus()));
         json = response.readEntity(JsonObject.class);
         Assert.assertEquals("ShareNotFound", json.getString("type"));
+
+        // Deletes share1 and share 2
+        String adminToken = adminToken();
+        target().path("/user/share1").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete();
+        target().path("/user/share2").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete();
     }
 }

--- a/docs-web/src/test/java/com/sismics/docs/rest/TestTagResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestTagResource.java
@@ -230,5 +230,11 @@ public class TestTagResource extends BaseJerseyTest {
         Assert.assertEquals(1, tags.size());
         Assert.assertEquals("UpdatedName", tags.getJsonObject(0).getString("name"));
         Assert.assertNull(tags.getJsonObject(0).get("parent"));
+
+        // Deletes user tag1
+        String adminToken = adminToken();
+        target().path("/user/tag1").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete();
     }
 }

--- a/docs-web/src/test/java/com/sismics/docs/rest/TestThemeResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestThemeResource.java
@@ -103,5 +103,13 @@ public class TestThemeResource extends BaseJerseyTest {
         // Get the background
         response = target().path("/theme/image/background").request().get();
         Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+        // Reset the main color as admin
+        target().path("/theme").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .post(Entity.form(new Form()
+                        .param("color", "#ffffff")
+                .param("name", "Teedy")
+                .param("css", "")), JsonObject.class);
     }
 }

--- a/docs-web/src/test/java/com/sismics/docs/rest/TestUserResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestUserResource.java
@@ -230,6 +230,11 @@ public class TestUserResource extends BaseJerseyTest {
                         .param("username", "alice")
                         .param("password", "12345678")));
         Assert.assertEquals(Status.FORBIDDEN, Status.fromStatusCode(response.getStatus()));
+
+        // Delete user bob
+        target().path("/user").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, bobToken)
+                .delete();
     }
 
     /**
@@ -416,7 +421,7 @@ public class TestUserResource extends BaseJerseyTest {
         response = target().path("/user/totp1").request()
                 .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
                 .delete();
-        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals(Response.Status.OK, Response.Status.fromStatusCode(response.getStatus()));
     }
 
     @Test
@@ -489,5 +494,11 @@ public class TestUserResource extends BaseJerseyTest {
         Assert.assertEquals(Response.Status.BAD_REQUEST, Response.Status.fromStatusCode(response.getStatus()));
         json = response.readEntity(JsonObject.class);
         Assert.assertEquals("KeyNotFound", json.getString("type"));
+
+        // Delete absent_minded
+        response = target().path("/user/absent_minded").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete();
+        Assert.assertEquals(Response.Status.OK, Response.Status.fromStatusCode(response.getStatus()));
     }
 }

--- a/docs-web/src/test/java/com/sismics/docs/rest/TestWebhookResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestWebhookResource.java
@@ -84,5 +84,10 @@ public class TestWebhookResource extends BaseJerseyTest {
                 .get(JsonObject.class);
         webhooks = json.getJsonArray("webhooks");
         Assert.assertEquals(0, webhooks.size());
+
+        // Deletes webhook1
+        target().path("/user/webhook1").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete();
     }
 }


### PR DESCRIPTION
Following up #757 : this PRs fixed the remaining non-idempotent unit tests in the repository.

## Test that depend on access permission:
- TestAppResource#testAppResource
Reason: The test first asserts that guest login is disabled in default state, and then enables guest login. In the second execution, the assertion will fail since guest login is globally enabled after the first test run.

Fix: Disable guest login before finishing test execution.

## Test that depend on default theme resource:
- TestThemeResource#testThemeResource
Reason: The test first asserts that the main color is (by default) `#ffffff`, but later changed it to `#ff0000`. It does not reset it back to `#ffffff` in the end, so the assertion will fail in the second test execution. 

Fix: Reset main color to `#ffffff` at the end of the test.

## Tests that creates users with fixed usernames:
- TestAuditLogResource#testAuditLogResource
- TestGroupResource#testGroupResource
- TestRouteModelResource#testRouteModelResource
- TestSecurity#testSecurity
- TestSecurity#testHeaderBasedAuthentication
- TestShareResource#testShareResource
- TestTagResource#testTagResource
- TestUserResource#testUserResource
- TestUserResource#testResetPassword
- TestWebhookResource#testWebhookResource
Reason: Similarly to previous discussion of `TestUserResource#testTotp` in #757 , the test creates a users with specific names without deleting them in the end. Therefore,  `HTTP 400 Bad Request` errors will occur on creating the users with the same names in the second executions, since the users already exist in the database. 

Fix: Delete the created users at the end of the tests.

## Tests that depend on the inherently non-idempotent `POST` method:
- TestAppResource#testSmtpConfiguration
- TestAppResource#testLdapAuthentication

Reason: Similarly to previous discussion of `TestAppResource#TestInbox` in #757 , these tests initially get specific configurations and asserts they're in default state. However, the non-revertible `POST` method changes these configurations, and there's no trivial way to restore this configurations to default. Hence, assertions of default configurations shall only be made in the first run of the test.

Fix: Add static flags to ensure that assertions with respect to default configurations are only executed in the first test execution.




